### PR TITLE
`BitAnd` and `AndNot` improvements

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -6,7 +6,7 @@ use criterion::{
     black_box, criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
     PlotConfiguration,
 };
-use ibig::{modular::ModuloRing, ops::DivRem, ubig, UBig};
+use ibig::{modular::ModuloRing, ops::DivRem, IBig, ubig, UBig};
 use rand::prelude::*;
 use std::fmt::Write;
 
@@ -28,6 +28,24 @@ fn bench_add(criterion: &mut Criterion) {
         let b = random_ubig(bits, &mut rng);
         group.bench_with_input(BenchmarkId::from_parameter(bits), &bits, |bencher, _| {
             bencher.iter(|| black_box(&a) + black_box(&b))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_and(criterion: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(1);
+    let mut group = criterion.benchmark_group("and");
+    group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+
+    for log_bits in 1..=6 {
+        let bits = 10usize.pow(log_bits);
+        let a: IBig = random_ubig(bits, &mut rng).into();
+        let a = -a;
+        let b: u64 = rng.gen();
+        group.bench_with_input(BenchmarkId::from_parameter(bits), &bits, |bencher, _| {
+            bencher.iter(|| black_box(&a) & black_box(&b))
         });
     }
 
@@ -219,6 +237,7 @@ fn bench_modulo_pow(criterion: &mut Criterion) {
 criterion_group!(
     benches,
     bench_add,
+    bench_and,
     bench_sub,
     bench_mul,
     bench_div,

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1547,7 +1547,7 @@ impl IBig {
         let (sign, magnitude) = self.into_sign_magnitude();
         let v = match (sign, magnitude.bitand_unsigned(T::MAX)) {
             (Positive, v) => v,
-            (Negative, v) => !v.wrapping_sub(T::from(1u8)),
+            (Negative, v) => T::from(0u8).wrapping_sub(v),
         };
         v & rhs
     }
@@ -1556,7 +1556,7 @@ impl IBig {
     fn bitand_ref_unsigned<T: PrimitiveUnsigned>(&self, rhs: T) -> T {
         let v = match (self.sign(), self.magnitude().bitand_ref_unsigned(T::MAX)) {
             (Positive, v) => v,
-            (Negative, v) => !v.wrapping_sub(T::from(1u8)),
+            (Negative, v) => T::from(0u8).wrapping_sub(v),
         };
         v & rhs
     }

--- a/tests/bits.rs
+++ b/tests/bits.rs
@@ -335,6 +335,7 @@ fn test_and_ibig() {
             let res: IBig = (a & b).into();
 
             assert_eq!(&a_big & &b_big, res);
+            assert_eq!(&a_big & b_big.clone(), res);
             assert_eq!(a_big.clone() & &b_big, res);
             assert_eq!(a_big.clone() & b_big.clone(), res);
 

--- a/tests/bits.rs
+++ b/tests/bits.rs
@@ -328,14 +328,13 @@ fn test_not_ibig() {
 
 #[test]
 fn test_and_ibig() {
-    for a in -20i8..=20i8 {
-        for b in -20i8..=20i8 {
+    for a in -255i16..=255i16 {
+        for b in -20i16..=20i16 {
             let a_big: IBig = a.into();
             let b_big: IBig = b.into();
             let res: IBig = (a & b).into();
 
             assert_eq!(&a_big & &b_big, res);
-            assert_eq!(&a_big & b_big.clone(), res);
             assert_eq!(a_big.clone() & &b_big, res);
             assert_eq!(a_big.clone() & b_big.clone(), res);
 
@@ -346,6 +345,13 @@ fn test_and_ibig() {
             let mut x = a_big.clone();
             x &= b_big.clone();
             assert_eq!(x, res);
+        }
+        
+        for b in 0u8..=255u8 {
+            let a_big: IBig = a.into();
+            let res = a as u8 & b;
+            assert_eq!(&a_big & b, res);
+            assert_eq!(a_big.clone() & b, res);
         }
     }
 }
@@ -401,15 +407,19 @@ fn test_xor_ibig() {
 #[test]
 fn test_and_not_ibig() {
     for a in -20i8..=20i8 {
-        for b in -20i8..=20i8 {
+        for b in -255i16..=255i16 {
             let a_big: IBig = a.into();
             let b_big: IBig = b.into();
-            let res: IBig = (a & !b).into();
+            let res = a as i16 & !b;
+            let res_big: IBig = res.into();
+            let res = res as i8;
 
-            assert_eq!((&a_big).and_not(&b_big), res);
-            assert_eq!((&a_big).and_not(b_big.clone()), res);
-            assert_eq!(a_big.clone().and_not(&b_big), res);
-            assert_eq!(a_big.clone().and_not(b_big.clone()), res);
+            assert_eq!(a.and_not(&b_big), res);
+            assert_eq!((&a_big).and_not(b), res_big);
+            assert_eq!((&a_big).and_not(&b_big), res_big);
+            assert_eq!((&a_big).and_not(b_big.clone()), res_big);
+            assert_eq!(a_big.clone().and_not(&b_big), res_big);
+            assert_eq!(a_big.clone().and_not(b_big.clone()), res_big);
         }
     }
 }
@@ -475,6 +485,11 @@ fn test_bit_ops_ubig_unsigned() {
     assert_eq!(ubig!(0xf0f).and_not(&0xffu8), ubig!(0xf00));
     assert_eq!((&ubig!(0xf0f)).and_not(0xffu8), ubig!(0xf00));
     assert_eq!((&ubig!(0xf0f)).and_not(&0xffu8), ubig!(0xf00));
+
+    assert_eq!(0xffu8.and_not(ubig!(0xf0f)), 0xF0);
+    assert_eq!(0xffu8.and_not(&ubig!(0xf0f)), 0xF0);
+    assert_eq!((&0xffu8).and_not(ubig!(0xf0f)), 0xF0);
+    assert_eq!((&0xffu8).and_not(&ubig!(0xf0f)), 0xF0);
 }
 
 #[test]


### PR DESCRIPTION
Added `AndNot<UBig> for $t` and `AndNot<IBig> for $t`
Added benchmark for `IBig & u64`
Optimized to avoid allocation (99.9% improvement for large numbers)
